### PR TITLE
Use .ShortText instead of .Text in the action instantiation description 

### DIFF
--- a/samples/com/cs/MyMessagingApp/Strings/en-US/Resources.resw
+++ b/samples/com/cs/MyMessagingApp/Strings/en-US/Resources.resw
@@ -118,11 +118,11 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="inputCombination1" xml:space="preserve">
-    <value>Send message to '${Contact.Text}'</value>
+    <value>Send message to '${Contact.ShortText}'</value>
     <comment>Description for first input combination</comment>
   </data>
   <data name="inputCombination2" xml:space="preserve">
-    <value>Send message to '${Contact.Text}' with text '${Message.Text}'</value>
+    <value>Send message to '${Contact.ShortText}' with text '${Message.ShortText}'</value>
     <comment>Description for 2nd input combination</comment>
   </data>
   <data name="MessageResult_1" xml:space="preserve">

--- a/samples/uri/cs/DisplayMessageApp/Assets/Actions.json
+++ b/samples/uri/cs/DisplayMessageApp/Assets/Actions.json
@@ -11,7 +11,7 @@
         }
       ],
       "outputs": [],
-      "instantiationDescription": "ms-resource://Resources/ActionDescription",
+      "instantiationDescription": "ms-resource://Resources/ActionInstantiationDescription",
       "invocation": {
         "type": "Uri",
         "uri": "display-message-app://displayMessage?message=${Message.Text}"

--- a/samples/uri/cs/DisplayMessageApp/Strings/en-US/Resources.resw
+++ b/samples/uri/cs/DisplayMessageApp/Strings/en-US/Resources.resw
@@ -121,6 +121,10 @@
     <value>Display a message</value>
     <comment>Description for action</comment>
   </data>
+  <data name="ActionInstantiationDescription" xml:space="preserve">
+    <value>Display message: '${Message.ShortText}'</value>
+    <comment>Description for action instantiation</comment>
+  </data>
   <data name="AppLaunchError" xml:space="preserve">
     <value>App was not launched via protocol or action wasn't detected.</value>
     <comment>Error when app fails to launch or detect action</comment>


### PR DESCRIPTION
In the action instantiation  descriptions, we want to concatenate the input that is displayed instead of displaying the full input:
![image](https://github.com/user-attachments/assets/4ae31b42-5530-40cb-abb6-95f06a7c44d4)
