### PR TITLE
update json schema with allowedAppInvokers field

### DIFF
--- a/samples/uri/cs/DisplayMessageApp/Assets/Actions.json
+++ b/samples/uri/cs/DisplayMessageApp/Assets/Actions.json
@@ -16,6 +16,23 @@
         "type": "Uri",
         "uri": "display-message-app://displayMessage?message=${Message.Text}"
       }
+    },
+    {
+      "id": "Samples.UriActions.DisplayMessageWithAllowedAppInvokersField",
+      "description": "ms-resource://Resources/ActionDescription",
+      "inputs": [
+        {
+          "name": "Message",
+          "kind": "Text"
+        }
+      ],
+      "allowedAppInvokers": [],
+      "outputs": [],
+      "instantiationDescription": "ms-resource://Resources/ActionInstantiationDescription",
+      "invocation": {
+        "type": "Uri",
+        "uri": "display-message-app://displayMessage?message=${Message.Text}"
+      }
     }
   ]
 }

--- a/schema/ActionsSchema.json
+++ b/schema/ActionsSchema.json
@@ -92,6 +92,11 @@
           "type": "string",
           "description": "Description of instantiation"
         },
+        "allowedAppInvokers": {
+          "type": "array",
+          "description": "List of App User Model IDs of apps that are allowed invoke this action",
+          "items": { "type" : "string" }
+        },
         "outputs": {
           "type": "array",
           "description": "Current output definitions",


### PR DESCRIPTION
This adds the new allowedAppInvokers field to the json, which can be used by the action producer to mention the list of App User Model IDs of apps that are allowed invoke the action